### PR TITLE
ci: cargo doc を走らせて生成物を自動チェックするCIジョブ追加

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,53 @@
+name: doc
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+        
+      - name: rustup override set `cat rust-toolchain`
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+
+      # https://github.com/actions/cache/blob/master/examples.md#rust---cargo
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: cargo clean --doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: clean
+          args: --doc
+      - name: cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+  
+      - run: cargo install cargo-deadlinks
+      - run: cargo deadlinks


### PR DESCRIPTION
別ブランチでrustdocを書いていて、structやenumへのリンクをしょっちゅう間違えるので、チェックがほしく作りました。

#11 ができあがったらそこへのpublishもこのワークフローでやる予定です。