### PR TITLE
refactor: Eliminates lifetime parameters from apllodb-storage-engine-interface

### DIFF
--- a/apllodb-immutable-schema-engine-application/src/use_case/transaction/alter_table.rs
+++ b/apllodb-immutable-schema-engine-application/src/use_case/transaction/alter_table.rs
@@ -1,4 +1,4 @@
-use crate::use_case::{UseCase, UseCaseInput, UseCaseOutput};
+use crate::use_case::{TxUseCase, UseCaseInput, UseCaseOutput};
 use apllodb_immutable_schema_engine_domain::{
     abstract_types::ImmutableSchemaAbstractTypes,
     version::repository::VersionRepository,
@@ -9,27 +9,12 @@ use apllodb_storage_engine_interface::StorageEngine;
 use std::{fmt::Debug, marker::PhantomData};
 
 #[derive(Eq, PartialEq, Hash, Debug, new)]
-pub struct AlterTableUseCaseInput<
-    'usecase,
-    'db: 'usecase,
-    Engine: StorageEngine<'usecase, 'db>,
-    Types: ImmutableSchemaAbstractTypes<'usecase, 'db, Engine>,
-> {
-    tx: &'usecase Engine::Tx,
+pub struct AlterTableUseCaseInput<'usecase> {
     database_name: &'usecase DatabaseName,
     table_name: &'usecase TableName,
     action: &'usecase AlterTableAction,
-
-    #[new(default)]
-    _marker: PhantomData<(&'db (), Types)>,
 }
-impl<
-        'usecase,
-        'db: 'usecase,
-        Engine: StorageEngine<'usecase, 'db>,
-        Types: ImmutableSchemaAbstractTypes<'usecase, 'db, Engine>,
-    > UseCaseInput for AlterTableUseCaseInput<'usecase, 'db, Engine, Types>
-{
+impl<'usecase> UseCaseInput for AlterTableUseCaseInput<'usecase> {
     fn validate(&self) -> ApllodbResult<()> {
         Ok(())
     }
@@ -42,7 +27,7 @@ impl UseCaseOutput for AlterTableUseCaseOutput {}
 pub struct AlterTableUseCase<
     'usecase,
     'db: 'usecase,
-    Engine: StorageEngine<'usecase, 'db>,
+    Engine: StorageEngine,
     Types: ImmutableSchemaAbstractTypes<'usecase, 'db, Engine>,
 > {
     _marker: PhantomData<(&'usecase &'db (), Engine, Types)>,
@@ -50,17 +35,18 @@ pub struct AlterTableUseCase<
 impl<
         'usecase,
         'db: 'usecase,
-        Engine: StorageEngine<'usecase, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'usecase, 'db, Engine>,
-    > UseCase for AlterTableUseCase<'usecase, 'db, Engine, Types>
+    > TxUseCase<'usecase, 'db, Engine, Types> for AlterTableUseCase<'usecase, 'db, Engine, Types>
 {
-    type In = AlterTableUseCaseInput<'usecase, 'db, Engine, Types>;
+    type In = AlterTableUseCaseInput<'usecase>;
     type Out = AlterTableUseCaseOutput;
 
-    fn run_core(input: Self::In) -> ApllodbResult<Self::Out> {
-        let vtable_repo = Types::VTableRepo::new(&input.tx);
-        let version_repo = Types::VersionRepo::new(&input.tx);
-
+    fn run_core(
+        vtable_repo: &Types::VTableRepo,
+        version_repo: &Types::VersionRepo,
+        input: Self::In,
+    ) -> ApllodbResult<Self::Out> {
         let vtable_id = VTableId::new(input.database_name, input.table_name);
         let mut vtable = vtable_repo.read(&vtable_id)?;
         vtable.alter(input.action)?;

--- a/apllodb-immutable-schema-engine-domain/src/abstract_types.rs
+++ b/apllodb-immutable-schema-engine-domain/src/abstract_types.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Types that must be implemented in an infrastructure layer.
-pub trait ImmutableSchemaAbstractTypes<'repo, 'db: 'repo, Engine: StorageEngine<'repo, 'db>>:
+pub trait ImmutableSchemaAbstractTypes<'repo, 'db: 'repo, Engine: StorageEngine>:
     Debug + Sized
 {
     type VRRId: VRRId;

--- a/apllodb-immutable-schema-engine-domain/src/row_iter.rs
+++ b/apllodb-immutable-schema-engine-domain/src/row_iter.rs
@@ -10,7 +10,7 @@ use crate::{abstract_types::ImmutableSchemaAbstractTypes, row::immutable_row::Im
 pub trait ImmutableSchemaRowIterator<
     'repo,
     'db: 'repo,
-    Engine: StorageEngine<'repo, 'db>,
+    Engine: StorageEngine,
     Types: ImmutableSchemaAbstractTypes<'repo, 'db, Engine>,
 >: Iterator<Item = ImmutableRow> + Debug
 {

--- a/apllodb-immutable-schema-engine-domain/src/version/repository.rs
+++ b/apllodb-immutable-schema-engine-domain/src/version/repository.rs
@@ -5,9 +5,7 @@ use apllodb_shared_components::{ApllodbResult, ColumnName, Expression};
 use apllodb_storage_engine_interface::StorageEngine;
 use std::collections::HashMap;
 
-pub trait VersionRepository<'repo, 'db: 'repo, Engine: StorageEngine<'repo, 'db>> {
-    fn new(tx: &'repo Engine::Tx) -> Self;
-
+pub trait VersionRepository<'repo, 'db: 'repo, Engine: StorageEngine> {
     /// Create a version.
     fn create(&self, version: &ActiveVersion) -> ApllodbResult<()>;
 

--- a/apllodb-immutable-schema-engine-domain/src/version_revision_resolver.rs
+++ b/apllodb-immutable-schema-engine-domain/src/version_revision_resolver.rs
@@ -17,7 +17,7 @@ use self::{vrr_entries::VRREntries, vrr_entry::VRREntry};
 pub trait VersionRevisionResolver<
     'vrr,
     'db: 'vrr,
-    Engine: StorageEngine<'vrr, 'db>,
+    Engine: StorageEngine,
     Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
 >
 {

--- a/apllodb-immutable-schema-engine-domain/src/version_revision_resolver/vrr_entries.rs
+++ b/apllodb-immutable-schema-engine-domain/src/version_revision_resolver/vrr_entries.rs
@@ -13,7 +13,7 @@ use super::{vrr_entries_in_version::VRREntriesInVersion, vrr_entry::VRREntry};
 pub struct VRREntries<
     'vrr,
     'db: 'vrr,
-    Engine: StorageEngine<'vrr, 'db>,
+    Engine: StorageEngine,
     Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
 > {
     vtable_id: VTableId,
@@ -23,7 +23,7 @@ pub struct VRREntries<
 impl<
         'vrr,
         'db: 'vrr,
-        Engine: StorageEngine<'vrr, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
     > VRREntries<'vrr, 'db, Engine, Types>
 {
@@ -59,7 +59,7 @@ impl<
 impl<
         'vrr,
         'db: 'vrr,
-        Engine: StorageEngine<'vrr, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
     > Iterator for VRREntries<'vrr, 'db, Engine, Types>
 {

--- a/apllodb-immutable-schema-engine-domain/src/version_revision_resolver/vrr_entries_in_version.rs
+++ b/apllodb-immutable-schema-engine-domain/src/version_revision_resolver/vrr_entries_in_version.rs
@@ -11,7 +11,7 @@ use super::{vrr_entries::VRREntries, vrr_entry::VRREntry};
 pub struct VRREntriesInVersion<
     'vrr,
     'db: 'vrr,
-    Engine: StorageEngine<'vrr, 'db>,
+    Engine: StorageEngine,
     Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
 > {
     version_id: VersionId,
@@ -21,7 +21,7 @@ pub struct VRREntriesInVersion<
 impl<
         'vrr,
         'db: 'vrr,
-        Engine: StorageEngine<'vrr, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
     > VRREntriesInVersion<'vrr, 'db, Engine, Types>
 {
@@ -44,7 +44,7 @@ impl<
 impl<
         'vrr,
         'db: 'vrr,
-        Engine: StorageEngine<'vrr, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
     > Iterator for VRREntriesInVersion<'vrr, 'db, Engine, Types>
 {

--- a/apllodb-immutable-schema-engine-domain/src/version_revision_resolver/vrr_entry.rs
+++ b/apllodb-immutable-schema-engine-domain/src/version_revision_resolver/vrr_entry.rs
@@ -18,7 +18,7 @@ use crate::{
 pub struct VRREntry<
     'vrr,
     'db: 'vrr,
-    Engine: StorageEngine<'vrr, 'db>,
+    Engine: StorageEngine,
     Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
 > {
     id: Types::VRRId,
@@ -30,7 +30,7 @@ pub struct VRREntry<
 impl<
         'vrr,
         'db: 'vrr,
-        Engine: StorageEngine<'vrr, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
     > VRREntry<'vrr, 'db, Engine, Types>
 {
@@ -51,7 +51,7 @@ impl<
 impl<
         'vrr,
         'db: 'vrr,
-        Engine: StorageEngine<'vrr, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
     > Clone for VRREntry<'vrr, 'db, Engine, Types>
 {
@@ -68,7 +68,7 @@ impl<
 impl<
         'vrr,
         'db: 'vrr,
-        Engine: StorageEngine<'vrr, 'db>,
+        Engine: StorageEngine,
         Types: ImmutableSchemaAbstractTypes<'vrr, 'db, Engine>,
     > Entity for VRREntry<'vrr, 'db, Engine, Types>
 {

--- a/apllodb-immutable-schema-engine-domain/src/vtable/repository.rs
+++ b/apllodb-immutable-schema-engine-domain/src/vtable/repository.rs
@@ -9,12 +9,10 @@ use apllodb_storage_engine_interface::StorageEngine;
 pub trait VTableRepository<
     'repo,
     'db: 'repo,
-    Engine: StorageEngine<'repo, 'db>,
+    Engine: StorageEngine,
     Types: ImmutableSchemaAbstractTypes<'repo, 'db, Engine>,
 >
 {
-    fn new(tx: &'repo Engine::Tx) -> Self;
-
     /// Create a new table with VTable.
     /// Do nothing for Version.
     ///

--- a/apllodb-immutable-schema-engine-infra/src/external_interface.rs
+++ b/apllodb-immutable-schema-engine-infra/src/external_interface.rs
@@ -1,19 +1,27 @@
+use std::marker::PhantomData;
+
 use crate::{
     immutable_schema_row_iter::ImmutableSchemaRowIter,
-    sqlite::transaction::{sqlite_tx::SqliteTx, tx_id::TxId},
+    sqlite::transaction::{
+        sqlite_tx::{SqliteTx, SqliteTxBuilder},
+        tx_id::TxId,
+    },
 };
 use apllodb_immutable_schema_engine_domain::row::immutable_row::ImmutableRow;
 use apllodb_shared_components::{ApllodbResult, DatabaseName};
-use apllodb_storage_engine_interface::StorageEngine;
+use apllodb_storage_engine_interface::{StorageEngine, Transaction};
 
 pub use crate::sqlite::database::SqliteDatabase as ApllodbImmutableSchemaDb;
 
 /// Storage engine implementation.
 #[derive(Hash, Debug)]
-pub struct ApllodbImmutableSchemaEngine;
+pub struct ApllodbImmutableSchemaEngine<'db> {
+    _marker: PhantomData<&'db ()>,
+}
 
-impl<'tx, 'db: 'tx> StorageEngine<'tx, 'db> for ApllodbImmutableSchemaEngine {
+impl<'db> StorageEngine for ApllodbImmutableSchemaEngine<'db> {
     type Tx = SqliteTx<'db>;
+    type TxBuilder = SqliteTxBuilder<'db>;
     type TID = TxId;
     type Db = ApllodbImmutableSchemaDb;
     type R = ImmutableRow;
@@ -22,5 +30,13 @@ impl<'tx, 'db: 'tx> StorageEngine<'tx, 'db> for ApllodbImmutableSchemaEngine {
     // TODO UndefinedDatabase error.
     fn use_database(database_name: &DatabaseName) -> ApllodbResult<ApllodbImmutableSchemaDb> {
         ApllodbImmutableSchemaDb::new(database_name.clone())
+    }
+}
+
+impl<'db> ApllodbImmutableSchemaEngine<'db> {
+    /// Starts transaction and get transaction object.
+    pub fn begin_transaction(db: &'db mut ApllodbImmutableSchemaDb) -> ApllodbResult<SqliteTx> {
+        let builder = SqliteTxBuilder::new(db);
+        SqliteTx::begin(builder)
     }
 }

--- a/apllodb-immutable-schema-engine-infra/src/immutable_schema_row_iter.rs
+++ b/apllodb-immutable-schema-engine-infra/src/immutable_schema_row_iter.rs
@@ -26,7 +26,8 @@ impl Iterator for ImmutableSchemaRowIter {
         })
     }
 }
-impl<'tx, 'db: 'tx> ImmutableSchemaRowIterator<'tx, 'db, ApllodbImmutableSchemaEngine, SqliteTypes>
+impl<'tx, 'db: 'tx>
+    ImmutableSchemaRowIterator<'tx, 'db, ApllodbImmutableSchemaEngine<'db>, SqliteTypes>
     for ImmutableSchemaRowIter
 {
     fn chain_versions(iters: impl IntoIterator<Item = SqliteRowIterator>) -> Self {

--- a/apllodb-immutable-schema-engine-infra/src/lib.rs
+++ b/apllodb-immutable-schema-engine-infra/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Infrastructure layer of apllodb-immutable-schema-engine.
 
+#[macro_use]
 extern crate derive_new;
 
 pub mod external_interface;

--- a/apllodb-immutable-schema-engine-infra/src/sqlite/sqlite_types.rs
+++ b/apllodb-immutable-schema-engine-infra/src/sqlite/sqlite_types.rs
@@ -17,7 +17,7 @@ use super::{
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct SqliteTypes;
 
-impl<'repo, 'db: 'repo> ImmutableSchemaAbstractTypes<'repo, 'db, ApllodbImmutableSchemaEngine>
+impl<'repo, 'db: 'repo> ImmutableSchemaAbstractTypes<'repo, 'db, ApllodbImmutableSchemaEngine<'db>>
     for SqliteTypes
 {
     type VRRId = SqliteRowid;
@@ -31,25 +31,25 @@ impl<'repo, 'db: 'repo> ImmutableSchemaAbstractTypes<'repo, 'db, ApllodbImmutabl
 
 // Fill structs' type parameters in domain / application layers.
 pub(crate) type VRREntriesInVersion<'vrr, 'db> =
-    apllodb_immutable_schema_engine_domain::version_revision_resolver::vrr_entries_in_version::VRREntriesInVersion<'vrr, 'db, ApllodbImmutableSchemaEngine, SqliteTypes>;
+    apllodb_immutable_schema_engine_domain::version_revision_resolver::vrr_entries_in_version::VRREntriesInVersion<'vrr, 'db, ApllodbImmutableSchemaEngine<'db>, SqliteTypes>;
 pub(crate) type VRREntries<'vrr, 'db> =
     apllodb_immutable_schema_engine_domain::version_revision_resolver::vrr_entries::VRREntries<
         'vrr,
         'db,
-        ApllodbImmutableSchemaEngine,
+        ApllodbImmutableSchemaEngine<'db>,
         SqliteTypes,
     >;
 pub(crate) type VRREntry<'vrr, 'db> =
     apllodb_immutable_schema_engine_domain::version_revision_resolver::vrr_entry::VRREntry<
         'vrr,
         'db,
-        ApllodbImmutableSchemaEngine,
+        ApllodbImmutableSchemaEngine<'db>,
         SqliteTypes,
     >;
 pub(crate) type ProjectionResult<'prj, 'db> =
     apllodb_immutable_schema_engine_domain::query::projection::ProjectionResult<
         'prj,
         'db,
-        ApllodbImmutableSchemaEngine,
+        ApllodbImmutableSchemaEngine<'db>,
         SqliteTypes,
     >;

--- a/apllodb-immutable-schema-engine-infra/src/sqlite/transaction/sqlite_tx/version/repository_impl.rs
+++ b/apllodb-immutable-schema-engine-infra/src/sqlite/transaction/sqlite_tx/version/repository_impl.rs
@@ -21,13 +21,15 @@ pub struct VersionRepositoryImpl<'repo, 'db: 'repo> {
     tx: &'repo SqliteTx<'db>,
 }
 
-impl<'repo, 'db: 'repo> VersionRepository<'repo, 'db, ApllodbImmutableSchemaEngine>
-    for VersionRepositoryImpl<'repo, 'db>
-{
-    fn new(tx: &'repo SqliteTx<'db>) -> Self {
+impl<'repo, 'db> VersionRepositoryImpl<'repo, 'db> {
+    pub fn new(tx: &'repo SqliteTx<'db>) -> Self {
         Self { tx }
     }
+}
 
+impl<'repo, 'db: 'repo> VersionRepository<'repo, 'db, ApllodbImmutableSchemaEngine<'db>>
+    for VersionRepositoryImpl<'repo, 'db>
+{
     /// # Failures
     ///
     /// - [DuplicateTable](apllodb_shared_components::ApllodbErrorKind::DuplicateTable) when:

--- a/apllodb-immutable-schema-engine-infra/src/sqlite/transaction/sqlite_tx/version_revision_resolver.rs
+++ b/apllodb-immutable-schema-engine-infra/src/sqlite/transaction/sqlite_tx/version_revision_resolver.rs
@@ -26,7 +26,8 @@ pub(crate) struct VersionRevisionResolverImpl<'vrr, 'db: 'vrr> {
     tx: &'vrr SqliteTx<'db>,
 }
 
-impl<'vrr, 'db: 'vrr> VersionRevisionResolver<'vrr, 'db, ApllodbImmutableSchemaEngine, SqliteTypes>
+impl<'vrr, 'db: 'vrr>
+    VersionRevisionResolver<'vrr, 'db, ApllodbImmutableSchemaEngine<'db>, SqliteTypes>
     for VersionRevisionResolverImpl<'vrr, 'db>
 {
     fn create_table(&self, vtable: &VTable) -> ApllodbResult<()> {

--- a/apllodb-immutable-schema-engine-infra/src/sqlite/transaction/sqlite_tx/vtable/repository_impl.rs
+++ b/apllodb-immutable-schema-engine-infra/src/sqlite/transaction/sqlite_tx/vtable/repository_impl.rs
@@ -28,13 +28,15 @@ pub struct VTableRepositoryImpl<'repo, 'db: 'repo> {
     tx: &'repo SqliteTx<'db>,
 }
 
-impl<'repo, 'db: 'repo> VTableRepository<'repo, 'db, ApllodbImmutableSchemaEngine, SqliteTypes>
-    for VTableRepositoryImpl<'repo, 'db>
-{
-    fn new(tx: &'repo SqliteTx<'db>) -> Self {
+impl<'repo, 'db> VTableRepositoryImpl<'repo, 'db> {
+    pub fn new(tx: &'repo SqliteTx<'db>) -> Self {
         Self { tx }
     }
+}
 
+impl<'repo, 'db: 'repo> VTableRepository<'repo, 'db, ApllodbImmutableSchemaEngine<'db>, SqliteTypes>
+    for VTableRepositoryImpl<'repo, 'db>
+{
     /// # Failures
     ///
     /// - [DuplicateTable](apllodb_shared_components::ApllodbErrorKind::DuplicateTable) when:

--- a/apllodb-immutable-schema-engine/tests/immutable_ddl.rs
+++ b/apllodb-immutable-schema-engine/tests/immutable_ddl.rs
@@ -7,7 +7,7 @@ use apllodb_shared_components::{
     ColumnName, ColumnReference, Constant, DataType, DataTypeKind, Expression, TableConstraintKind,
     TableConstraints, TableName,
 };
-use apllodb_storage_engine_interface::{ProjectionQuery, StorageEngine, Transaction};
+use apllodb_storage_engine_interface::{ProjectionQuery, Transaction};
 
 #[test]
 fn test_success_select_column_available_only_in_1_of_2_versions() -> ApllodbResult<()> {

--- a/apllodb-immutable-schema-engine/tests/pk.rs
+++ b/apllodb-immutable-schema-engine/tests/pk.rs
@@ -6,7 +6,7 @@ use apllodb_shared_components::{
     ApllodbResult, ColumnConstraints, ColumnDefinition, ColumnName, ColumnReference, Constant,
     DataType, DataTypeKind, Expression, TableConstraintKind, TableConstraints, TableName,
 };
-use apllodb_storage_engine_interface::{ProjectionQuery, StorageEngine, Transaction};
+use apllodb_storage_engine_interface::{ProjectionQuery, Transaction};
 
 #[test]
 fn test_compound_pk() -> ApllodbResult<()> {

--- a/apllodb-immutable-schema-engine/tests/standard_sql.rs
+++ b/apllodb-immutable-schema-engine/tests/standard_sql.rs
@@ -7,7 +7,7 @@ use apllodb_shared_components::{
     ColumnReference, Constant, DataType, DataTypeKind, Expression, TableConstraintKind,
     TableConstraints, TableName,
 };
-use apllodb_storage_engine_interface::{ProjectionQuery, Row, StorageEngine, Transaction};
+use apllodb_storage_engine_interface::{ProjectionQuery, Row, Transaction};
 
 #[test]
 fn test_create_table_success() -> ApllodbResult<()> {

--- a/apllodb-immutable-schema-engine/tests/transaction.rs
+++ b/apllodb-immutable-schema-engine/tests/transaction.rs
@@ -6,7 +6,7 @@ use apllodb_shared_components::{
     ApllodbErrorKind, ApllodbResult, ColumnConstraints, ColumnDefinition, ColumnName,
     ColumnReference, DataType, DataTypeKind, TableConstraintKind, TableConstraints, TableName,
 };
-use apllodb_storage_engine_interface::{StorageEngine, Transaction};
+use apllodb_storage_engine_interface::Transaction;
 
 #[test]
 fn test_wait_lock() -> ApllodbResult<()> {

--- a/apllodb-immutable-schema-engine/tests/use_apllodb_immutable_schema_engine.rs
+++ b/apllodb-immutable-schema-engine/tests/use_apllodb_immutable_schema_engine.rs
@@ -6,7 +6,7 @@ use apllodb_shared_components::{
     ApllodbResult, ColumnConstraints, ColumnDefinition, ColumnName, ColumnReference, DataType,
     DataTypeKind, TableConstraintKind, TableConstraints, TableName,
 };
-use apllodb_storage_engine_interface::{StorageEngine, Transaction};
+use apllodb_storage_engine_interface::Transaction;
 
 #[test]
 fn test_use_apllodb_immutable_schema_engine() -> ApllodbResult<()> {

--- a/apllodb-storage-engine-interface/src/transaction.rs
+++ b/apllodb-storage-engine-interface/src/transaction.rs
@@ -9,6 +9,11 @@ use std::{collections::HashMap, fmt::Debug};
 
 use crate::{ProjectionQuery, StorageEngine};
 
+/// Transaction builder.
+/// Implement this to contain reference type in it.
+/// (Without builder, [Transaction::begin()](crate::Transaction::begin) may take reference type and it should take lifetime parameter although Transaction is a trait.)
+pub trait TransactionBuilder: Debug {}
+
 /// Transaction interface.
 ///
 /// It has methods to control transaction's lifetime (BEGIN, COMMIT/ABORT)
@@ -18,13 +23,12 @@ use crate::{ProjectionQuery, StorageEngine};
 ///
 /// Implementation of this trait can either execute physical transaction operations (e.g. locking objects, writing logs to disk, etc...)
 /// directly or delegate physical operations to another object.
-pub trait Transaction<'tx, 'db: 'tx, Engine: StorageEngine<'tx, 'db>>: Debug + 'tx {
+pub trait Transaction<Engine: StorageEngine>: Debug {
     /// Transaction ID
     fn id(&self) -> &Engine::TID;
 
     /// Begins a transaction.
-    /// A database cannot starts multiple transactions at a time (&mut reference enforces it).
-    fn begin(db: &'db mut Engine::Db) -> ApllodbResult<Self>
+    fn begin(builder: Engine::TxBuilder) -> ApllodbResult<Self>
     where
         Self: Sized;
 


### PR DESCRIPTION
fixes: https://github.com/darwin-education/apllodb/issues/38

@rot1024 コードリーディング中に自分で気になってた部分の修正です。マージはしてしまいますが説明したことと変わるのでメンションします。

lifetime parameterは実装詳細のためのものなのに、interfaceであるtraitにくっついているとおかしい（例えば全く参照を使わないでストレージエンジンを実装する場合は邪魔でしかない）ので、なんとか排除しました。

今まで必要になっていた理由は、

1. infa層のstruct実装が `tx: &'tx SqliteTx` というメンバを抱えている
2. コンストラクタは `fn new(tx &'tx: SqliteTx) {...}` のようにlifetime parameterを取る
3. コンストラクタをinfra層より下でも使うために、traitにも `fn new(tx &'tx: SqliteTx);` を持たせる

とやっていたためでした。
3が誤った方針で、コンストラクタは実装詳細であるinfra層だけに持たせるようにしたら、interface側でのlifetime parameterを排除できました。