### PR TITLE
feat: Translates ApllodbAst's Constant into `apllodb_shared_components::Constant`

### DIFF
--- a/apllodb-immutable-schema-engine-application/src/use_case/transaction/update_all.rs
+++ b/apllodb-immutable-schema-engine-application/src/use_case/transaction/update_all.rs
@@ -34,7 +34,7 @@ impl<'usecase> UpdateAllUseCaseInput<'usecase> {
         for (column_name, expr) in &self.column_values {
             match expr {
                 Expression::ConstantVariant(_) => {}
-                Expression::ColumnReferenceVariant(_) | Expression::BooleanExpressionVariant(_) => {
+                Expression::ColumnNameVariant(_) | Expression::BooleanExpressionVariant(_) => {
                     return Err(ApllodbError::new(ApllodbErrorKind::FeatureNotSupported,
                         format!("trying to UpdateAll `{:?}={:?}` while expr of `UpdateAll INTO ... VALUES (expr ...)`. `expr` can only be a constant", 
                         column_name, expr

--- a/apllodb-immutable-schema-engine-domain/src/row/pk/apparent_pk.rs
+++ b/apllodb-immutable-schema-engine-domain/src/row/pk/apparent_pk.rs
@@ -157,10 +157,7 @@ impl ApparentPrimaryKey {
             .map(|(column_name, sql_value)| {
                 let constant_expr = Constant::from(sql_value);
                 ComparisonFunction::EqualVariant {
-                    left: Box::new(Expression::ColumnReferenceVariant(ColumnReference::new(
-                        self.table_name.clone(),
-                        column_name.clone(),
-                    ))),
+                    left: Box::new(Expression::ColumnNameVariant(column_name.clone())),
                     right: Box::new(Expression::ConstantVariant(constant_expr)),
                 }
             })

--- a/apllodb-immutable-schema-engine-infra/src/sqlite/to_sql_string.rs
+++ b/apllodb-immutable-schema-engine-infra/src/sqlite/to_sql_string.rs
@@ -3,9 +3,8 @@ use apllodb_immutable_schema_engine_domain::{
     row::pk::full_pk::revision::Revision, version::version_number::VersionNumber,
 };
 use apllodb_shared_components::{
-    BooleanExpression, CharacterConstant, ColumnDataType, ColumnName, ColumnReference,
-    ComparisonFunction, Constant, DataType, DataTypeKind, Expression, LogicalFunction,
-    NumericConstant, SqlValue, TableName,
+    BooleanExpression, CharacterConstant, ColumnDataType, ColumnName, ComparisonFunction, Constant,
+    DataType, DataTypeKind, Expression, LogicalFunction, NumericConstant, SqlValue, TableName,
 };
 
 pub(in crate::sqlite) trait ToSqlString {
@@ -56,12 +55,6 @@ impl ToSqlString for TableName {
 impl ToSqlString for ColumnName {
     fn to_sql_string(&self) -> String {
         self.as_str().to_string()
-    }
-}
-
-impl ToSqlString for ColumnReference {
-    fn to_sql_string(&self) -> String {
-        self.to_string()
     }
 }
 
@@ -148,9 +141,7 @@ impl ToSqlString for Expression {
     fn to_sql_string(&self) -> String {
         match self {
             Expression::ConstantVariant(c) => c.to_sql_string(),
-            Expression::ColumnReferenceVariant(column_reference) => {
-                column_reference.to_sql_string()
-            }
+            Expression::ColumnNameVariant(column_name) => column_name.to_sql_string(),
             Expression::BooleanExpressionVariant(boolean_expr) => boolean_expr.to_sql_string(),
         }
     }

--- a/apllodb-shared-components/src/data_structure/expression.rs
+++ b/apllodb-shared-components/src/data_structure/expression.rs
@@ -3,11 +3,9 @@ pub(crate) mod constant;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ColumnReference;
-
 use self::{boolean_expression::BooleanExpression, constant::Constant};
 
-use super::value::sql_value::SqlValue;
+use super::{column::column_name::ColumnName, value::sql_value::SqlValue};
 
 /// Expression.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
@@ -15,8 +13,8 @@ pub enum Expression {
     /// Constant
     ConstantVariant(Constant),
 
-    /// Reference to column reference
-    ColumnReferenceVariant(ColumnReference),
+    /// Reference to column value
+    ColumnNameVariant(ColumnName),
 
     /// Boolean expression
     BooleanExpressionVariant(BooleanExpression),

--- a/apllodb-shared-components/src/data_structure/value/sql_value.rs
+++ b/apllodb-shared-components/src/data_structure/value/sql_value.rs
@@ -302,11 +302,11 @@ impl SqlValue {
                     }
                 },
             },
-            Expression::ColumnReferenceVariant(column_reference) => Err(ApllodbError::new(
+            Expression::ColumnNameVariant(column_name) => Err(ApllodbError::new(
                 ApllodbErrorKind::DataException,
                 format!(
                     "cannot construct SqlValue from column reference: {:?}",
-                    column_reference
+                    column_name
                 ),
                 None,
             )),


### PR DESCRIPTION
これがあれば、sql-processor がINSERTを受け取ったときに、SQLだけから（テーブルスキーマ情報を storage engine に問い合わせることなしに）RecordIteratorを構築できる。