### PR TITLE
fix: error message no more contains `DummyError`

### DIFF
--- a/apllodb-shared-components/src/error.rs
+++ b/apllodb-shared-components/src/error.rs
@@ -87,7 +87,6 @@ impl std::fmt::Debug for ApllodbError {
             self.source()
                 .map_or_else(|| "None".to_string(), |e| format!("{:?}", e))
         )
-
     }
 }
 


### PR DESCRIPTION
ApllodbError の source が空のときに、実装詳細の `DummyError` が Debug プリントされていたのを修正