### PR TITLE
ci: not use --release for testing in order to cover `debug_assert!()` for example

### DIFF
--- a/.github/workflows/correct-and-check-pr.yml
+++ b/.github/workflows/correct-and-check-pr.yml
@@ -132,13 +132,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --tests --release --all-features
+          args: --tests --all-features
 
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --all-features
+          args: --all-features
 
   check_rustdoc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
昔個人プロジェクトで `--release` じゃないと再現しないランタイムエラーあって、CIでつけるのが癖になっていたが、多分あの頃のコードが異常だっただけでしょう。

`debug_assert!()` とか、 i32 の境界値チェックとかがテストでされないほうが問題としてでかいので、オプション外す