### PR TITLE
ci: fix dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
-version: 1
+version: 2
 updates:
-  - package-ecosystem: "rust:cargo"
+  - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Dependabot encountered the following error when parsing your .github/dependabot.yml:

```
The property '#/version' value 1 did not match one of the following values: 2
The property '#/updates/0/package-ecosystem' value "rust:cargo" did not match one of the following values: npm, bundler, composer, maven, mix, cargo, gradle, nuget, gomod, docker, elm, gitsubmodule, github-actions, pip, terraform
```

Please update the config file to conform with Dependabot's specification.

Learn more or give us feedback